### PR TITLE
Add crosshair guidance to computer tool description

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -64,7 +64,12 @@ const computerTool: Tool = {
 * Some applications may take time to start or process actions, so you may need to wait and take successive screenshots to see the results of your actions. E.g. if you click on Firefox and a window doesn't open, try taking another screenshot.
 * Whenever you intend to move the cursor to click on an element like an icon, you should consult a screenshot to determine the coordinates of the element before moving the cursor.
 * If you tried clicking on a program or link but it failed to load, even after waiting, try adjusting your cursor position so that the tip of the cursor visually falls on the element that you want to click.
-* Make sure to click any buttons, links, icons, etc with the cursor tip in the center of the element. Don't click boxes on their edges unless asked.`,
+* Make sure to click any buttons, links, icons, etc with the cursor tip in the center of the element. Don't click boxes on their edges unless asked.
+
+Using the crosshair:
+* Screenshots show a red crosshair at the current cursor position.
+* After clicking, check where the crosshair appears vs your target. If it missed, adjust coordinates proportionally to the distance - start with large adjustments and refine. Avoid small incremental changes when the crosshair is far from the target (distances are often further than you expect).
+* Consider display dimensions when estimating positions. E.g. if it's 90% to the bottom of the screen, the coordinates should reflect this.`,
 	inputSchema: {
 		type: 'object',
 		properties: {


### PR DESCRIPTION
Add instructions for using the red crosshair overlay that appears in screenshots. This helps the model make better cursor position adjustments by:

- Explaining that screenshots show a red crosshair at the current cursor position
- Guiding to make proportional adjustments based on distance rather than small incremental changes
- Considering display dimensions when estimating positions