### PR TITLE
Fix manifest entrypoint to use main.js

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -15,10 +15,10 @@
   },
   "server": {
     "type": "node",
-    "entry_point": "dist/index.js",
+    "entry_point": "dist/main.js",
     "mcp_config": {
       "command": "node",
-      "args": ["${__dirname}/dist/index.js"]
+      "args": ["${__dirname}/dist/main.js"]
     }
   },
   "tools": [


### PR DESCRIPTION
The entrypoint moved from index.js to main.js in the SDK refactor but the manifest wasn't updated.