### PR TITLE
Fix HTTP transport cross-client response misrouting

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -44,17 +44,19 @@ function setupSignalHandlers(cleanup: () => Promise<void>): void {
 		const app = express();
 		app.use(express.json());
 
-		const httpTransport = new StreamableHTTPServerTransport({
-			sessionIdGenerator: undefined,
-			enableJsonResponse: true,
-		});
-
+		// Stateless: fresh server + transport per request — sharing either misroutes responses on concurrent requests with colliding JSON-RPC IDs (GHSA-345p-7cg4-v4c7).
 		app.post('/mcp', async (req, res) => {
+			const server = createServer();
+			const httpTransport = new StreamableHTTPServerTransport({
+				sessionIdGenerator: undefined,
+				enableJsonResponse: true,
+			});
+			res.on('close', () => {
+				void server.close();
+			});
+			await server.connect(httpTransport);
 			await httpTransport.handleRequest(req, res, req.body);
 		});
-
-		const server = createServer();
-		await server.connect(httpTransport);
 
 		const port = parseInt(process.env.PORT || '3000', 10);
 		const httpServer = app.listen(port, () => {
@@ -63,7 +65,6 @@ function setupSignalHandlers(cleanup: () => Promise<void>): void {
 		});
 
 		setupSignalHandlers(async () => {
-			await server.close();
 			httpServer.close();
 		});
 	} else {


### PR DESCRIPTION
## Summary

`src/main.ts` previously created a single `StreamableHTTPServerTransport` (stateless, `sessionIdGenerator: undefined`) and a single `McpServer`, then reused both across every `/mcp` request. This is the exact pattern called out by [GHSA-345p-7cg4-v4c7](https://github.com/advisories/GHSA-345p-7cg4-v4c7): with two concurrent clients, JSON-RPC IDs collide (the SDK's default client uses an incrementing counter starting at 0), and the transport's internal `requestId → res` map gets overwritten — so a tool result for client A can be written to client B's HTTP response.

This PR moves construction inside the `app.post('/mcp', ...)` handler, matching the advisory's prescribed workaround. `res.on('close', ...)` ensures the per-request server is closed when the connection ends.

stdio mode is unchanged.

## Test plan

- [x] `npm run build`
- [x] `npm test` — 9 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)