### PR TITLE
docs: link desktop install instructions to CI builds filtered to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ This installs the server at user scope (available in all projects). To install l
 
 #### (Recommended) Via manual .dxt installation
 
-1. Find the latest dxt build in [the GitHub Actions history](https://github.com/domdomegg/computer-use-mcp/actions/workflows/dxt.yaml?query=branch%3Amaster) (the top one)
+1. Find the latest dxt build in [the GitHub Actions history](https://github.com/domdomegg/computer-use-mcp/actions/workflows/ci.yaml?query=branch%3Amaster) (the top one)
 2. In the 'Artifacts' section, download the `computer-use-mcp-dxt` file
 3. Rename the `.zip` file to `.dxt`
 4. Double-click the `.dxt` file to open with Claude Desktop


### PR DESCRIPTION
Fixes #65

Updates the desktop install instructions in the README to link to the CI builds list filtered to the `master` branch (`?query=branch%3Amaster`), so readers land on builds from master instead of the unfiltered actions list which includes PR builds.