### PR TITLE
docs: update install instructions from .dxt to .mcpb

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,12 @@ This installs the server at user scope (available in all projects). To install l
 <details>
 <summary><strong>Claude Desktop</strong></summary>
 
-#### (Recommended) Via manual .dxt installation
+#### (Recommended) Via manual .mcpb installation
 
-1. Find the latest dxt build in [the GitHub Actions history](https://github.com/domdomegg/computer-use-mcp/actions/workflows/ci.yaml?query=branch%3Amaster) (the top one)
-2. In the 'Artifacts' section, download the `computer-use-mcp-dxt` file
-3. Rename the `.zip` file to `.dxt`
-4. Double-click the `.dxt` file to open with Claude Desktop
+1. Find the latest mcpb build in [the GitHub Actions history](https://github.com/domdomegg/computer-use-mcp/actions/workflows/ci.yaml?query=branch%3Amaster) (the top one)
+2. In the 'Artifacts' section, download the `computer-use-mcp-mcpb` file
+3. Rename the `.zip` file to `.mcpb`
+4. Double-click the `.mcpb` file to open with Claude Desktop
 5. Click "Install"
 
 #### (Advanced) Alternative: Via JSON configuration


### PR DESCRIPTION
Follow-up to #66.

The MCP bundle format was renamed from `.dxt` to `.mcpb`. `build-mcpb.sh` and the CI artifact (`computer-use-mcp-mcpb`) already use the new name, but the README install instructions still referenced `.dxt` — the section heading, the artifact name in step 2, and the file extension in steps 3-4. Updated to match what CI actually produces.

The "rename the .zip to .mcpb" wording is still correct: CI unzips the built `.mcpb` into `.github/tmp/` before uploading, so `actions/upload-artifact` re-zips the bundle contents at the root — the downloaded zip is structurally the same as the `.mcpb` file.